### PR TITLE
feat(cover): add STOP support to shade (SYSTEM_SHADE) covers

### DIFF
--- a/custom_components/lutron_lip/cover.py
+++ b/custom_components/lutron_lip/cover.py
@@ -575,6 +575,7 @@ class LutronCover(LutronOutput, CoverEntity):
         CoverEntityFeature.OPEN
         | CoverEntityFeature.CLOSE
         | CoverEntityFeature.SET_POSITION
+        | CoverEntityFeature.STOP
     )
 
     _attr_is_closed: bool | None = None
@@ -604,6 +605,10 @@ class LutronCover(LutronOutput, CoverEntity):
         if ATTR_POSITION in kwargs:
             position = kwargs[ATTR_POSITION]
             await self._execute_device_command(self._lutron_device.set_level, position)
+
+    async def async_stop_cover(self, **kwargs: Any) -> None:
+        """Stop the shade mid-travel (LIP #OUTPUT,<id>,4)."""
+        await self._execute_device_command(self._lutron_device.stop)
 
     async def _request_state(self) -> None:
         """Request the state of the cover."""


### PR DESCRIPTION
Fixes #61.

`SYSTEM_SHADE` outputs are mapped to `LutronCover`, which advertised only OPEN/CLOSE/SET_POSITION — so `cover.stop_cover` was unavailable on all shade entities. The underlying `Output.stop()` command builder (LIP `#OUTPUT,<id>,4`) already exists and is used by `LutronCoverTimeBased`; this wires it into `LutronCover` and adds `CoverEntityFeature.STOP`.

## Testing
Verified on a HomeWorks QS processor. Closing a shade and calling `cover.stop_cover` mid-travel halts it, and the processor reports the true intermediate level (e.g. `~OUTPUT,20,1,72.35`), which now surfaces as the entity's position.

## Note
STOP is honored by the shade outputs I tested (HomeWorks QS). Processors/outputs that ignore `#OUTPUT,<id>,4` would treat it as a no-op rather than erroring.
