### PR TITLE
fix(protocol): survive a bridge-initiated connection reset

### DIFF
--- a/custom_components/lutron_lip/aiolip/protocol.py
+++ b/custom_components/lutron_lip/aiolip/protocol.py
@@ -216,6 +216,16 @@ class LIP:
             raise
 
         # set the correct monitoring
+        await self._async_setup_monitoring()
+
+    async def _async_setup_monitoring(self):
+        """Subscribe to the unsolicited updates we care about.
+
+        Monitoring is session scoped, so this has to be re-issued after every
+        reconnect -- not just on the initial connect. Without it the socket is
+        healthy and outgoing commands still work, but the bridge never pushes
+        state changes back and every entity goes stale.
+        """
         await self.action(LIPMode.MONITORING, 12, 2)  # disable prompt state
         await self.action(
             LIPMode.MONITORING, 255, 2
@@ -278,20 +288,44 @@ class LIP:
             self._socket = None
 
         self._reconnecting_event.set()
-        async with self._read_connect_lock:
-            self.connection_state = LIPConnectionState.NOT_CONNECTED
-            while not self._disconnect_event.is_set():
-                try:
-                    await self._async_connect(self._host)
-                except (TimeoutError, OSError):
-                    _LOGGER.debug(
-                        "Timed out while trying to reconnect to %s", self._host
+        try:
+            async with self._read_connect_lock:
+                self.connection_state = LIPConnectionState.NOT_CONNECTED
+                while not self._disconnect_event.is_set():
+                    try:
+                        await self._async_connect(self._host)
+                        await self._async_setup_monitoring()
+                    except Exception as ex:  # noqa: BLE001
+                        # Deliberately broad. This retry loop is the only thing
+                        # that can bring the link back, so nothing may escape
+                        # it: an escaping exception leaves _reconnecting_event
+                        # set forever, and the guard at the top of this method
+                        # then makes every future reconnect a no-op while
+                        # connection_state stays CONNECTING -- the integration
+                        # wedges until it is reloaded by hand. A bridge that
+                        # garbles its login banner mid-handshake raises
+                        # LIPProtocolError here, which is not an OSError.
+                        _LOGGER.debug("Reconnect to %s failed: %s", self._host, ex)
+                        # _async_connect leaves the state at CONNECTING and the
+                        # half-open socket assigned when it raises part-way
+                        # through; clean both up or we leak a session on the
+                        # bridge with every attempt.
+                        if self._socket:
+                            self._socket.close()
+                            self._socket = None
+                        self.connection_state = LIPConnectionState.NOT_CONNECTED
+                        await asyncio.sleep(RECONNECT_DELAY)
+                        continue
+
+                    _LOGGER.info(
+                        "Restored monitoring after reconnect to %s", self._host
                     )
-                    # Back-off a bit before the next reconnect attempt to avoid a busy loop.
-                    await asyncio.sleep(RECONNECT_DELAY)
-                else:
                     self._keepalive_watchdog()
                     return
+        finally:
+            # Belt and braces: _async_connect clears this on success, but if we
+            # leave by any other route it must not stay set.
+            self._reconnecting_event.clear()
 
     async def async_stop(self):
         """Disconnect from the bridge."""
@@ -332,6 +366,15 @@ class LIP:
             or self.connection_state != LIPConnectionState.CONNECTED
         ):
             return
+
+        # Drop any still-pending timer first. Every reconnect calls back into
+        # this method, and without this each one starts an additional
+        # self-rescheduling chain -- N reconnects means N keep-alives a minute
+        # against a bridge that is already struggling. Cancelling an
+        # already-fired handle (the self-rescheduling case) is a no-op.
+        if self._keep_alive_task:
+            self._keep_alive_task.cancel()
+            self._keep_alive_task = None
 
         self._keep_alive_reconnect_task = asyncio.create_task(
             self._async_keep_alive_or_reconnect()
@@ -385,6 +428,14 @@ class LIP:
             return
         except (asyncio.InvalidStateError, BrokenPipeError) as ex:
             _LOGGER.debug("Error processing message", exc_info=ex)
+            return
+        except OSError as ex:
+            # The bridge reset the socket mid-read. Without this the exception
+            # escapes async_run(), killing the reader task for good: outgoing
+            # commands keep working (they reconnect on demand) but no state
+            # update is ever read again. Reconnect and let async_run() loop.
+            _LOGGER.info("Lutron connection lost while reading (%s), reconnecting", ex)
+            await self._async_disconnected()
             return
 
     def _process_message(self, response):


### PR DESCRIPTION
## Motivation

I think I lost power very briefly. After everything rebooted, I found my lutron-lip integration was flaky. I had to periodically reload it to fix it. I could send commands but I wasn't getting updates about the state of lights. I'm planning on power cycling my lutron controller it to try and fix it, but first I thought I'd ask Claude to see if it could make the integration a little bit more resilient to whatever was happening.

## Summary

After the Lutron bridge resets the LIP socket, the integration ends up in a state where **outgoing commands still work but no state update is ever received again**. Lights can still be controlled from Home Assistant, but changes made at a keypad — or by Home Assistant itself — are never reflected back. The only recovery is reloading the config entry by hand.

This turns out to be three separate faults on the same path. Each one alone is enough to produce the symptom, so all three need fixing to make a reset survivable.

## 1. The reader task dies permanently on a connection reset

`LIPSocket.async_readline()` raises `ConnectionResetError` when the bridge drops the socket. In `_async_run_once()`, the `read_task.result()` call is guarded by:

```python
except TimeoutError:
except (asyncio.InvalidStateError, BrokenPipeError) as ex:
```

`ConnectionResetError` matches neither. It propagates out of `_async_run_once()`, out of the `while` loop in `async_run()`, and kills the task created in `LutronController.connect()`. Nothing ever restarts it, so nothing reads the socket again for the lifetime of the config entry.

Outgoing commands keep working because they reach the bridge through `_ensure_connected()` on a separate path. That asymmetry is what makes this present as "control works, updates are broken" rather than as a plain disconnect.

**Fix:** catch `OSError` (the parent of `ConnectionResetError`) around message processing, trigger a reconnect, and return so `async_run()` keeps looping.

## 2. Monitoring is never re-subscribed after a reconnect

The `#MONITORING` subscriptions are what make the bridge push unsolicited updates. They are issued only in `async_connect()`, which runs once at setup:

```python
await self.action(LIPMode.MONITORING, 255, 2)  # disable everything
await self.action(LIPMode.MONITORING, 5, 1)    # Zone
...
```

The reconnect path in `_async_disconnected()` calls the private `_async_connect()` directly, and that does socket + login only. A reconnected session is therefore authenticated and writable but never re-subscribed, so the update feed stays dead even once the socket is healthy again.

**Fix:** extract the subscriptions into `_async_setup_monitoring()` and call it from both `async_connect()` and the reconnect path. If the subscriptions fail, treat the attempt as a failed reconnect and retry, rather than settling on a connection that can send but never receives.

## 3. A failed reconnect can wedge the integration permanently

`_async_disconnected()` sets `_reconnecting_event`, then retries `_async_connect()` catching only `(TimeoutError, OSError)`. But `_async_connect()` can also raise `LIPProtocolError`, via `_verify_expected_response()`, when the bridge garbles its login banner — which a struggling bridge does.

That exception escapes the loop with `_reconnecting_event` still set. From then on:

- the guard at the top of `_async_disconnected()` turns every future reconnect into a silent no-op, and
- `connection_state` is stuck at `CONNECTING`, because `_async_connect()` sets it on entry and never resets it on failure,

so `_ensure_connected()` raises `LIPConnectionStateError` on every subsequent poll and **every entity goes unavailable until the entry is reloaded by hand**.

Related, on the same path: when `_async_connect()` raises after `asyncio.open_connection()` has already succeeded, `self._socket` is left assigned and never closed, leaking a session on the bridge with each failed attempt. Bridges permit only a small number of concurrent telnet sessions, so repeated failures can exhaust them.

**Fix:** catch broadly in the retry loop, reset `connection_state` and close the half-open socket between attempts, and clear `_reconnecting_event` in a `finally`.

## 4. Duplicate keep-alive chains (minor)

`_keepalive_watchdog()` re-arms itself via `loop.call_later()`, and `_async_disconnected()` also calls it on every successful reconnect without cancelling the pending timer. Depending on timing the old chain survives, so keep-alive traffic can multiply with each reconnect — additional load on a bridge that is already failing.

**Fix:** cancel any pending handle first. Cancelling an already-fired handle is a no-op, so the normal self-rescheduling case is unaffected.

## Evidence

Captured on a RadioRA 2 processor that had begun resetting integration connections several times a day. With the patch applied, a real reset now self-heals in about five seconds and updates continue afterwards:

```
T+0s     INFO  Lutron connection lost while reading ([Errno 104] Connection reset by peer), reconnecting
T+5s     INFO  Restored monitoring after reconnect to <bridge>
T+27m    light.<zone_a>  ->  off      (unsolicited update received after the reconnect)
T+84m    light.<zone_b>  ->  off      (unsolicited update received well after the reconnect)
```

Before the patch, that same reset produced this traceback, after which no further update was ever received:

```
File "custom_components/lutron_lip/aiolip/protocol.py", line 353, in async_run
File "custom_components/lutron_lip/aiolip/protocol.py", line 383, in _async_run_once
File "custom_components/lutron_lip/aiolip/protocol.py", line  68, in async_readline
ConnectionResetError: [Errno 104] Connection reset by peer
```

Line numbers are against `master` at the time of writing, which is identical to `v.0.1.4`.

## Scope

Touches `custom_components/lutron_lip/aiolip/protocol.py` only. No config, entity, or public API changes, and no new dependencies. Behaviour against a healthy bridge is unchanged — every new code path is on the failure side.

One deliberate style exception: the broad `except Exception` in the reconnect retry loop. It is load-bearing rather than lazy, since anything escaping that loop reintroduces fault 3. It is commented as such in the diff.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
